### PR TITLE
Make tracing exporter settings configurable

### DIFF
--- a/charts/gorse-enterprise/README.md
+++ b/charts/gorse-enterprise/README.md
@@ -52,6 +52,15 @@
 | `gorse.recommends[0].replacement.decay.read`        | Decay the weights of replaced items from read feedbacks                       | `0.6`        |
 | `gorse.recommends[0].online.fallback`               | The fallback recommendation method is used when cached recommendation drained | `["latest"]` |
 
+### Tracing configuration
+
+| Name                              | Description                                 | Value                              |
+| --------------------------------- | ------------------------------------------- | ---------------------------------- |
+| `gorse.tracing.enable`            | Enable tracing for REST APIs                | `false`                            |
+| `gorse.tracing.exporter`          | Tracing exporter type (zipkin\|otlp\|otlphttp) | `otlphttp`                      |
+| `gorse.tracing.collectorEndpoint` | Tracing collector endpoint                  | `http://localhost:4318/v1/traces` |
+| `gorse.tracing.sampler`           | Tracing sampler type (always\|never\|ratio) | `always`                           |
+| `gorse.tracing.ratio`             | Ratio used when sampler is set to ratio     | `1`                                |
 ### Gorse master node parameters
 
 | Name                                      | Description                                                                                                                      | Value                    |
@@ -282,4 +291,3 @@
 | `externalDatabase.database`                  | Gorse database name                                                       | `gorse`             |
 | `externalDatabase.existingSecret`            | Name of an existing secret resource containing the database credentials   | `""`                |
 | `externalDatabase.existingSecretPasswordKey` | Name of an existing secret key containing the database credentials        | `mongodb-passwords` |
-

--- a/charts/gorse-enterprise/README.md
+++ b/charts/gorse-enterprise/README.md
@@ -56,11 +56,11 @@
 
 | Name                              | Description                                 | Value                              |
 | --------------------------------- | ------------------------------------------- | ---------------------------------- |
-| `gorse.tracing.enable`            | Enable tracing for REST APIs                | `false`                            |
-| `gorse.tracing.exporter`          | Tracing exporter type (zipkin\|otlp\|otlphttp) | `otlphttp`                      |
-| `gorse.tracing.collectorEndpoint` | Tracing collector endpoint                  | `http://localhost:4318/v1/traces` |
-| `gorse.tracing.sampler`           | Tracing sampler type (always\|never\|ratio) | `always`                           |
-| `gorse.tracing.ratio`             | Ratio used when sampler is set to ratio     | `1`                                |
+| `standalone.tracing.enable`            | Enable tracing for REST APIs                | `false`                            |
+| `standalone.tracing.exporter`          | Tracing exporter type (zipkin\|otlp\|otlphttp) | `otlphttp`                      |
+| `standalone.tracing.collectorEndpoint` | Tracing collector endpoint                  | `http://localhost:4318/v1/traces` |
+| `standalone.tracing.sampler`           | Tracing sampler type (always\|never\|ratio) | `always`                           |
+| `standalone.tracing.ratio`             | Ratio used when sampler is set to ratio     | `1`                                |
 ### Gorse master node parameters
 
 | Name                                      | Description                                                                                                                      | Value                    |

--- a/charts/gorse-enterprise/templates/configmap.yaml
+++ b/charts/gorse-enterprise/templates/configmap.yaml
@@ -104,17 +104,17 @@ data:
     [tracing]
 
     # Enable tracing for REST APIs. The default value is false.
-    enable_tracing = false
+    enable_tracing = {{ $.Values.gorse.tracing.enable | default false }}
 
-    # The type of tracing exporters should be one of "jaeger", "zipkin", "otlp" and "otlphttp". The default value is "jaeger".
-    exporter = "jaeger"
+    # The type of tracing exporters should be one of "zipkin", "otlp" and "otlphttp". The default value is "otlphttp".
+    exporter = {{ $.Values.gorse.tracing.exporter | quote }}
 
     # The endpoint of tracing collector.
-    collector_endpoint = "http://localhost:14268/api/traces"
+    collector_endpoint = {{ $.Values.gorse.tracing.collectorEndpoint | quote }}
 
     # The type of tracing sampler should be one of "always", "never" and "ratio". The default value is "always".
-    sampler = "always"
+    sampler = {{ $.Values.gorse.tracing.sampler | quote }}
 
     # The ratio of ratio based sampler. The default value is 1.
-    ratio = 1
+    ratio = {{ $.Values.gorse.tracing.ratio }}
 {{- end }}

--- a/charts/gorse-enterprise/templates/configmap.yaml
+++ b/charts/gorse-enterprise/templates/configmap.yaml
@@ -104,17 +104,17 @@ data:
     [tracing]
 
     # Enable tracing for REST APIs. The default value is false.
-    enable_tracing = {{ $.Values.gorse.tracing.enable | default false }}
+    enable_tracing = {{ $.Values.standalone.tracing.enable | default false }}
 
     # The type of tracing exporters should be one of "zipkin", "otlp" and "otlphttp". The default value is "otlphttp".
-    exporter = {{ $.Values.gorse.tracing.exporter | quote }}
+    exporter = {{ $.Values.standalone.tracing.exporter | quote }}
 
     # The endpoint of tracing collector.
-    collector_endpoint = {{ $.Values.gorse.tracing.collectorEndpoint | quote }}
+    collector_endpoint = {{ $.Values.standalone.tracing.collectorEndpoint | quote }}
 
     # The type of tracing sampler should be one of "always", "never" and "ratio". The default value is "always".
-    sampler = {{ $.Values.gorse.tracing.sampler | quote }}
+    sampler = {{ $.Values.standalone.tracing.sampler | quote }}
 
     # The ratio of ratio based sampler. The default value is 1.
-    ratio = {{ $.Values.gorse.tracing.ratio }}
+    ratio = {{ $.Values.standalone.tracing.ratio }}
 {{- end }}

--- a/charts/gorse-enterprise/values.yaml
+++ b/charts/gorse-enterprise/values.yaml
@@ -365,6 +365,25 @@ standalone:
   ##
   initContainers: []
 
+  ## @section Tracing configuration
+  ##
+  tracing:
+    ## @param gorse.tracing.enable Enable tracing for REST APIs
+    ##
+    enable: false
+    ## @param gorse.tracing.exporter Tracing exporter type (zipkin|otlp|otlphttp)
+    ##
+    exporter: "otlphttp"
+    ## @param gorse.tracing.collectorEndpoint Tracing collector endpoint
+    ##
+    collectorEndpoint: "http://localhost:4318/v1/traces"
+    ## @param gorse.tracing.sampler Tracing sampler type (always|never|ratio)
+    ##
+    sampler: "always"
+    ## @param gorse.tracing.ratio Ratio used when sampler is set to ratio
+    ##
+    ratio: 1
+
 ## @section Gorse master node parameters
 ##
 master:

--- a/charts/gorse-enterprise/values.yaml
+++ b/charts/gorse-enterprise/values.yaml
@@ -364,10 +364,6 @@ standalone:
   ##    command: ['sh', '-c', 'echo "hello world"']
   ##
   initContainers: []
-
-## @section Tracing configuration
-##
-standalone:
   tracing:
     ## @param standalone.tracing.enable Enable tracing for REST APIs
     ##

--- a/charts/gorse-enterprise/values.yaml
+++ b/charts/gorse-enterprise/values.yaml
@@ -365,22 +365,23 @@ standalone:
   ##
   initContainers: []
 
-  ## @section Tracing configuration
-  ##
+## @section Tracing configuration
+##
+standalone:
   tracing:
-    ## @param gorse.tracing.enable Enable tracing for REST APIs
+    ## @param standalone.tracing.enable Enable tracing for REST APIs
     ##
     enable: false
-    ## @param gorse.tracing.exporter Tracing exporter type (zipkin|otlp|otlphttp)
+    ## @param standalone.tracing.exporter Tracing exporter type (zipkin|otlp|otlphttp)
     ##
     exporter: "otlphttp"
-    ## @param gorse.tracing.collectorEndpoint Tracing collector endpoint
+    ## @param standalone.tracing.collectorEndpoint Tracing collector endpoint
     ##
     collectorEndpoint: "http://localhost:4318/v1/traces"
-    ## @param gorse.tracing.sampler Tracing sampler type (always|never|ratio)
+    ## @param standalone.tracing.sampler Tracing sampler type (always|never|ratio)
     ##
     sampler: "always"
-    ## @param gorse.tracing.ratio Ratio used when sampler is set to ratio
+    ## @param standalone.tracing.ratio Ratio used when sampler is set to ratio
     ##
     ratio: 1
 

--- a/charts/gorse/README.md
+++ b/charts/gorse/README.md
@@ -139,6 +139,16 @@ The command removes all the Kubernetes components associated with the chart and 
 | `gorse.oidc.clientSecret` | OAuth application client secret      | `""`    |
 | `gorse.oidc.redirectUrl`  | OAuth redirect/callback URL          | `""`    |
 
+### Tracing configuration
+
+| Name                              | Description                                 | Value                              |
+| --------------------------------- | ------------------------------------------- | ---------------------------------- |
+| `gorse.tracing.enable`            | Enable tracing for REST APIs                | `false`                            |
+| `gorse.tracing.exporter`          | Tracing exporter type (zipkin\|otlp\|otlphttp) | `otlphttp`                      |
+| `gorse.tracing.collectorEndpoint` | Tracing collector endpoint                  | `http://localhost:4318/v1/traces` |
+| `gorse.tracing.sampler`           | Tracing sampler type (always\|never\|ratio) | `always`                           |
+| `gorse.tracing.ratio`             | Ratio used when sampler is set to ratio     | `1`                                |
+
 ### Gorse master node parameters
 
 

--- a/charts/gorse/templates/configmap.yaml
+++ b/charts/gorse/templates/configmap.yaml
@@ -129,19 +129,19 @@ data:
     [tracing]
 
     # Enable tracing for REST APIs. The default value is false.
-    enable_tracing = false
+    enable_tracing = {{ .Values.gorse.tracing.enable | default false }}
 
-    # The type of tracing exporters should be one of "jaeger", "zipkin", "otlp" and "otlphttp". The default value is "jaeger".
-    exporter = "jaeger"
+    # The type of tracing exporters should be one of "zipkin", "otlp" and "otlphttp". The default value is "otlphttp".
+    exporter = {{ .Values.gorse.tracing.exporter | quote }}
 
     # The endpoint of tracing collector.
-    collector_endpoint = "http://localhost:14268/api/traces"
+    collector_endpoint = {{ .Values.gorse.tracing.collectorEndpoint | quote }}
 
     # The type of tracing sampler should be one of "always", "never" and "ratio". The default value is "always".
-    sampler = "always"
+    sampler = {{ .Values.gorse.tracing.sampler | quote }}
 
     # The ratio of ratio based sampler. The default value is 1.
-    ratio = 1
+    ratio = {{ .Values.gorse.tracing.ratio }}
 
     [oidc]
 

--- a/charts/gorse/values.yaml
+++ b/charts/gorse/values.yaml
@@ -147,6 +147,25 @@ gorse:
     ##
     logFile: "openai.log"
 
+  ## @section Tracing configuration
+  ##
+  tracing:
+    ## @param gorse.tracing.enable Enable tracing for REST APIs
+    ##
+    enable: false
+    ## @param gorse.tracing.exporter Tracing exporter type (zipkin|otlp|otlphttp)
+    ##
+    exporter: "otlphttp"
+    ## @param gorse.tracing.collectorEndpoint Tracing collector endpoint
+    ##
+    collectorEndpoint: "http://localhost:4318/v1/traces"
+    ## @param gorse.tracing.sampler Tracing sampler type (always|never|ratio)
+    ##
+    sampler: "always"
+    ## @param gorse.tracing.ratio Ratio used when sampler is set to ratio
+    ##
+    ratio: 1
+
   ## @section OIDC configuration
   ##
   oidc:


### PR DESCRIPTION
This PR makes tracing configurable in the Helm charts instead of hardcoding tracing settings in the rendered `config.toml`.

## Changes

- added `gorse.tracing` values to both `gorse` and `gorse-enterprise` charts
- made tracing settings configurable from `values.yaml`
- updated tracing defaults to use supported exporter values
- updated chart documentation for the new tracing parameters