### PR TITLE
feat: rename recommends to pipelines and add per-pipeline externalDatabase

### DIFF
--- a/charts/gorse-enterprise/templates/_helpers.tpl
+++ b/charts/gorse-enterprise/templates/_helpers.tpl
@@ -25,9 +25,9 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "gorse.proxy.endpoints" -}}
-{{- range $i, $recommend := .Values.gorse.recommends -}}
+{{- range $i, $pipeline := .Values.gorse.pipelines -}}
     {{- printf "http://%s:%d" (printf "%s-%s" (include "gorse.server.fullname" $) .name) ($.Values.server.service.ports.http | int) -}}
-    {{- if not (eq (add $i 1) (len $.Values.gorse.recommends)) -}}
+    {{- if not (eq (add $i 1) (len $.Values.gorse.pipelines)) -}}
         {{- printf "," -}}
     {{- end -}}
 {{- end -}}

--- a/charts/gorse-enterprise/templates/configmap.yaml
+++ b/charts/gorse-enterprise/templates/configmap.yaml
@@ -1,9 +1,9 @@
-{{- range $recommend := .Values.gorse.recommends }}
+{{- range $pipeline := .Values.gorse.pipelines }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ printf "%s-%s" (include "common.names.fullname" $ ) $recommend.name }}
+  name: {{ printf "%s-%s" (include "common.names.fullname" $ ) $pipeline.name }}
   namespace: {{ $.Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     {{- if $.Values.commonLabels }}
@@ -16,26 +16,16 @@ data:
   config.toml: |
     [database]
 
-    # The database for caching, support Redis, MySQL, Postgres and MongoDB:
-    #   redis://<user>:<password>@<host>:<port>/<db_number>
-    #   rediss://<user>:<password>@<host>:<port>/<db_number>
-    #   redis+cluster://<user>:<password>@<host1>:<port1>,<host2>:<port2>,...,<hostN>:<portN>
-    #   postgres://bob:secret@1.2.3.4:5432/mydb?sslmode=verify-full
-    #   postgresql://bob:secret@1.2.3.4:5432/mydb?sslmode=verify-full
-    #   mongodb://[username:password@]host1[:port1][,...hostN[:portN]][/[defaultauthdb][?options]]
-    #   mongodb+srv://[username:password@]host1[:port1][,...hostN[:portN]][/[defaultauthdb][?options]]
-    cache_store = "redis://localhost:6379/0"
-
-    # The database for persist data, support MySQL, Postgres, ClickHouse and MongoDB:
-    #   mysql://[username[:password]@][protocol[(address)]]/dbname[?param1=value1&...&paramN=valueN]
-    #   postgres://bob:secret@1.2.3.4:5432/mydb?sslmode=verify-full
-    #   postgresql://bob:secret@1.2.3.4:5432/mydb?sslmode=verify-full
-    #   clickhouse://user:password@host[:port]/database?param1=value1&...&paramN=valueN
-    #   chhttp://user:password@host[:port]/database?param1=value1&...&paramN=valueN
-    #   chhttps://user:password@host[:port]/database?param1=value1&...&paramN=valueN
-    #   mongodb://[username:password@]host1[:port1][,...hostN[:portN]][/[defaultauthdb][?options]]
-    #   mongodb+srv://[username:password@]host1[:port1][,...hostN[:portN]][/[defaultauthdb][?options]]
-    data_store = "mysql://gorse:gorse_pass@tcp(localhost:3306)/gorse"
+    {{- if $pipeline.externalDatabase.host }}
+    # The database for caching (using pipeline-specific externalDatabase)
+    cache_store = "mongodb://{{ $pipeline.externalDatabase.username }}:{{ $pipeline.externalDatabase.password }}@{{ $pipeline.externalDatabase.host }}:{{ $pipeline.externalDatabase.port }}/{{ $pipeline.externalDatabase.database }}"
+    # The database for persist data (using pipeline-specific externalDatabase)
+    data_store = "mongodb://{{ $pipeline.externalDatabase.username }}:{{ $pipeline.externalDatabase.password }}@{{ $pipeline.externalDatabase.host }}:{{ $pipeline.externalDatabase.port }}/{{ $pipeline.externalDatabase.database }}"
+    {{- end }}
+    {{- if not $pipeline.externalDatabase.host }}
+    # The database for caching and persist data will be set via environment variables
+    # cache_store and data_store are injected by GORSE_CACHE_STORE and GORSE_DATA_STORE
+    {{- end }}
 
     # The naming prefix for tables (collections, keys) in databases.
     table_prefix = ""
@@ -97,8 +87,8 @@ data:
     # Server-side cache expire time. The default value is 10s.
     cache_expire = {{ $.Values.gorse.api.serverCacheExpire | quote }}
 
-    {{- if $recommend.config }}
-    {{ $recommend.config | nindent 4 }}
+    {{- if $pipeline.recommend }}
+    {{ $pipeline.recommend | nindent 4 }}
     {{- end }}
 
     [tracing]

--- a/charts/gorse-enterprise/templates/master/deployment.yaml
+++ b/charts/gorse-enterprise/templates/master/deployment.yaml
@@ -1,11 +1,11 @@
 {{- if eq .Values.architecture "distributed" }}
 {{- if eq .Values.architecture "distributed" }}
-{{- range $recommend := .Values.gorse.recommends }}
+{{- range $pipeline := .Values.gorse.pipelines }}
 ---
 apiVersion: apps/v1
 kind: {{ $.Values.master.kind }}
 metadata:
-  name: {{ printf "%s-%s" (include "gorse.master.fullname" $ ) $recommend.name }}
+  name: {{ printf "%s-%s" (include "gorse.master.fullname" $ ) $pipeline.name }}
   namespace: {{ $.Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     app.kubernetes.io/component: master
@@ -91,6 +91,7 @@ spec:
               value: "{{ $.Values.master.service.ports.http }}"
             - name: GORSE_MASTER_JOBS
               value: "{{ $.Values.master.jobs }}"
+            {{- if not $pipeline.externalDatabase.host }}
             - name: GORSE_DATABASE_HOST
               value: {{ include "gorse.databaseHost" $ }}
             - name: GORSE_DATABASE_PORT
@@ -108,6 +109,7 @@ spec:
               value: mongodb://$(GORSE_DATABASE_USER):$(GORSE_DATABASE_PASSWORD)@$(GORSE_DATABASE_HOST):$(GORSE_DATABASE_PORT)/$(GORSE_DATABASE_NAME)?connect=direct
             - name: GORSE_DATA_STORE
               value: mongodb://$(GORSE_DATABASE_USER):$(GORSE_DATABASE_PASSWORD)@$(GORSE_DATABASE_HOST):$(GORSE_DATABASE_PORT)/$(GORSE_DATABASE_NAME)?connect=direct
+            {{- end }}
           volumeMounts:
             - name: config
               mountPath: /etc/gorse/
@@ -142,7 +144,7 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: {{ printf "%s-%s" (include "common.names.fullname" $ ) $recommend.name }}
+            name: {{ printf "%s-%s" (include "common.names.fullname" $ ) $pipeline.name }}
   {{- if not $.Values.master.persistence.enabled }}
         - name: data
           {{- if $.Values.master.persistence.medium }}
@@ -158,7 +160,7 @@ spec:
   {{- else if (eq $.Values.master.kind "Deployment") }}
         - name: data
           persistentVolumeClaim:
-            claimName: {{ printf "%s-%s" (include "gorse.master.fullname" $ ) $recommend.name }}
+            claimName: {{ printf "%s-%s" (include "gorse.master.fullname" $ ) $pipeline.name }}
   {{- else }}
   volumeClaimTemplates:
     - metadata:

--- a/charts/gorse-enterprise/templates/master/pvc.yaml
+++ b/charts/gorse-enterprise/templates/master/pvc.yaml
@@ -1,12 +1,12 @@
 {{- if eq .Values.architecture "distributed" }}
 {{- if eq .Values.architecture "distributed" }}
-{{- range $recommend := .Values.gorse.recommends }}
+{{- range $pipeline := .Values.gorse.pipelines }}
 ---
 {{- if and (eq $.Values.master.kind "Deployment") ($.Values.master.persistence.enabled) (not $.Values.master.persistence.existingClaim) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ printf "%s-%s" (include "gorse.master.fullname" $ ) $recommend.name }}
+  name: {{ printf "%s-%s" (include "gorse.master.fullname" $ ) $pipeline.name }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: master

--- a/charts/gorse-enterprise/templates/master/service.yaml
+++ b/charts/gorse-enterprise/templates/master/service.yaml
@@ -1,11 +1,11 @@
 {{- if eq .Values.architecture "distributed" }}
 {{- if eq .Values.architecture "distributed" }}
-{{- range $recommend := .Values.gorse.recommends }}
+{{- range $pipeline := .Values.gorse.pipelines }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-%s" (include "gorse.master.fullname" $ ) $recommend.name }}
+  name: {{ printf "%s-%s" (include "gorse.master.fullname" $ ) $pipeline.name }}
   namespace: {{ $.Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     app.kubernetes.io/component: master

--- a/charts/gorse-enterprise/templates/server/deployment.yaml
+++ b/charts/gorse-enterprise/templates/server/deployment.yaml
@@ -1,11 +1,11 @@
 {{- if eq .Values.architecture "distributed" }}
 {{- if eq .Values.architecture "distributed" }}
-{{- range $recommend := .Values.gorse.recommends }}
+{{- range $pipeline := .Values.gorse.pipelines }}
 ---
 apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
-  name: {{ printf "%s-%s" (include "gorse.server.fullname" $ ) $recommend.name }}
+  name: {{ printf "%s-%s" (include "gorse.server.fullname" $ ) $pipeline.name }}
   namespace: {{ $.Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     app.kubernetes.io/component: sever

--- a/charts/gorse-enterprise/templates/server/hpa.yaml
+++ b/charts/gorse-enterprise/templates/server/hpa.yaml
@@ -1,12 +1,12 @@
 {{- if eq .Values.architecture "distributed" }}
 {{- if eq .Values.architecture "distributed" }}
 {{- if and .Values.server.autoscaling.enabled }}
-{{- range $recommend := .Values.gorse.recommends }}
+{{- range $pipeline := .Values.gorse.pipelines }}
 ---
 apiVersion: {{ include "common.capabilities.hpa.apiVersion" ( dict "context" $ ) }}
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ printf "%s-%s" (include "gorse.server.fullname" $ ) $recommend.name }}
+  name: {{ printf "%s-%s" (include "gorse.server.fullname" $ ) $pipeline.name }}
   namespace: {{ $.Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     app.kubernetes.io/component: server

--- a/charts/gorse-enterprise/templates/server/service.yaml
+++ b/charts/gorse-enterprise/templates/server/service.yaml
@@ -1,11 +1,11 @@
 {{- if eq .Values.architecture "distributed" }}
 {{- if eq .Values.architecture "distributed" }}
-{{- range $recommend := .Values.gorse.recommends }}
+{{- range $pipeline := .Values.gorse.pipelines }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-%s" (include "gorse.server.fullname" $ ) $recommend.name }}
+  name: {{ printf "%s-%s" (include "gorse.server.fullname" $ ) $pipeline.name }}
   namespace: {{ $.Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     app.kubernetes.io/component: server

--- a/charts/gorse-enterprise/templates/worker/deployment.yaml
+++ b/charts/gorse-enterprise/templates/worker/deployment.yaml
@@ -1,11 +1,11 @@
 {{- if eq .Values.architecture "distributed" }}
 {{- if eq .Values.architecture "distributed" }}
-{{- range $recommend := $.Values.gorse.recommends }}
+{{- range $pipeline := $.Values.gorse.pipelines }}
 ---
 apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
-  name: {{ printf "%s-%s" (include "gorse.worker.fullname" $ ) $recommend.name }}
+  name: {{ printf "%s-%s" (include "gorse.worker.fullname" $ ) $pipeline.name }}
   namespace: {{ $.Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     app.kubernetes.io/component: sever

--- a/charts/gorse-enterprise/templates/worker/hpa.yaml
+++ b/charts/gorse-enterprise/templates/worker/hpa.yaml
@@ -1,12 +1,12 @@
 {{- if eq .Values.architecture "distributed" }}
 {{- if eq .Values.architecture "distributed" }}
-{{- range $recommend := $.Values.gorse.recommends }}
+{{- range $pipeline := .Values.gorse.pipelines }}
 ---
 {{- if and $.Values.worker.autoscaling.enabled }}
 apiVersion: {{ include "common.capabilities.hpa.apiVersion" ( dict "context" $ ) }}
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ printf "%s-%s" (include "gorse.worker.fullname" $ ) $recommend.name }}
+  name: {{ printf "%s-%s" (include "gorse.worker.fullname" $ ) $pipeline.name }}
   namespace: {{ $.Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     app.kubernetes.io/component: worker

--- a/charts/gorse-enterprise/templates/worker/service.yaml
+++ b/charts/gorse-enterprise/templates/worker/service.yaml
@@ -1,12 +1,12 @@
 {{- if eq .Values.architecture "distributed" }}
 {{- if eq .Values.architecture "distributed" }}
-{{- range $recommend := .Values.gorse.recommends }}
+{{- range $pipeline := .Values.gorse.pipelines }}
 ---
 {{- if $.Values.worker.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-%s" (include "gorse.worker.fullname" $ ) $recommend.name }}
+  name: {{ printf "%s-%s" (include "gorse.worker.fullname" $ ) $pipeline.name }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: worker

--- a/charts/gorse-enterprise/values.yaml
+++ b/charts/gorse-enterprise/values.yaml
@@ -88,18 +88,31 @@ gorse:
     ##
     serverCacheExpire: "10s"
 
-  recommends:
-    ## @param gorse.recommends[0].name The name of recommend channel
+  pipelines:
+    ## @param gorse.pipelines[0].name The name of recommend channel
     ##
     - name: default
-      ## @param gorse.recommends[0].config TOML string for recommend configuration
+      ## @param gorse.pipelines[0].recommend TOML string for recommend configuration
       ## Example:
-      ## config: |
+      ## recommend: |
       ##   [recommend]
       ##   cache_size = 100
       ##   [recommend.data_source]
       ##   positive_feedback_types = ["star", "like"]
-      config: ""
+      recommend: ""
+      ## External database configuration for cache storage
+      ## @param gorse.pipelines[0].externalDatabase.host Database host for cache
+      ## @param gorse.pipelines[0].externalDatabase.port Database port for cache
+      ## @param gorse.pipelines[0].externalDatabase.username Database username for cache
+      ## @param gorse.pipelines[0].externalDatabase.password Database password for cache
+      ## @param gorse.pipelines[0].externalDatabase.database Database name for cache
+      ##
+      externalDatabase:
+        host: ""
+        port: 27017
+        username: ""
+        password: ""
+        database: ""
 
 ## @section Gorse standalone (gorse-in-one) parameters
 ## Only used when architecture is set to `standalone`


### PR DESCRIPTION
## Summary
- Rename `gorse.recommends` to `gorse.pipelines` for clearer naming
- Rename `pipeline.config` to `pipeline.recommend` 
- Add `externalDatabase` config for each pipeline to support separate cache storage per pipeline

## Changes
- Updated all template files to use `$pipeline` instead of `$recommend`
- Added `externalDatabase` field in pipeline configuration with `host`, `port`, `username`, `password`, `database` options
- When `pipeline.externalDatabase.host` is set, database connection strings are written directly to config.toml
- When not set, fallback to global mongodb configuration via environment variables

## Test plan
- [x] Run `helm dependency build` to fetch dependencies
- [x] Run `helm template` with default values - verified configmap shows comment about env vars, deployment has env vars injected
- [x] Run `helm template` with pipeline externalDatabase set - verified configmap has direct connection strings, deployment has no database env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)